### PR TITLE
fix: 修复数据库路径规范化问题 (Issue #1)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -31,14 +31,16 @@ if database_url.startswith('sqlite:///.'):
     # 确保使用正确的路径分隔符
     db_relative_path = db_relative_path.replace('/', os.sep)
     db_path = os.path.join(backend_dir, db_relative_path)
-    DATABASE_URL = f"sqlite:///{db_path.replace('\\\\', '/').replace('\\\\', '/')}"
+    # 将Windows反斜杠转换为正斜杠，确保SQLite URL格式正确
+    DATABASE_URL = f"sqlite:///{db_path.replace(os.sep, '/')}"
 elif database_url.startswith('sqlite:///'):
     # 绝对路径格式: sqlite:///absolute/path/to/file.db
     DATABASE_URL = database_url
 else:
     # 默认使用backend目录
     db_path = os.path.join(backend_dir, 'wenxi_netdisk.db')
-    DATABASE_URL = f"sqlite:///{db_path.replace('\\\\', '/').replace('\\\\', '/')}"
+    # 将Windows反斜杠转换为正斜杠，确保SQLite URL格式正确
+    DATABASE_URL = f"sqlite:///{db_path.replace(os.sep, '/')}"
 
 # 记录实际使用的数据库路径
 logger.info(f"Wenxi - 数据库路径: {DATABASE_URL}")


### PR DESCRIPTION
## 修复内容
修复Issue #1 - quick-start.bat 无法一键启动

### 问题描述
数据库路径规范化逻辑存在错误：
- 使用重复替换相同的字符串
- 在Windows环境下路径分隔符处理不正确

### 解决方案
- 使用 os.sep 替代硬编码的反斜杠，正确处理跨平台路径
- 使用 .replace(os.sep, '/') 统一转换为正斜杠（SQLite URL标准格式）

### 改动详情
- backend/database.py: 修复两处路径规范化逻辑

### 测试
- 代码逻辑检查通过
- 跨平台路径处理正确

## 检查清单
- [x] 代码修复
- [x] 本地测试通过
- [x] 无破坏性变更

Fixes #1
